### PR TITLE
Do not call methods unnecessarily

### DIFF
--- a/app/Http/Controllers/IvrController.php
+++ b/app/Http/Controllers/IvrController.php
@@ -45,29 +45,24 @@ class IvrController extends Controller
      */
     public function showMenuResponse(Request $request)
     {
-        $optionActions = [
-            '1' => $this->_getReturnInstructions(),
-            '2' => $this->_getPlanetsMenu()
-        ];
         $selectedOption = $request->input('Digits');
 
-        $actionExists = isset($optionActions[$selectedOption]);
-
-        if ($actionExists) {
-            $selectedAction = $optionActions[$selectedOption];
-            return $selectedAction;
-
-        } else {
-            $response = new Services_Twilio_Twiml;
-            $response->say(
-                'Returning to the main menu',
-                ['voice' => 'Alice', 'language' => 'en-GB']
-            );
-            $response->redirect(route('welcome', [], false));
-
-            return $response;
+        switch ($selectedOption)
+        {
+            case 1:
+                return $this->_getReturnInstructions();
+            case 2:
+                return $this->_getPlanetsMenu();
         }
 
+        $response = new Services_Twilio_Twiml;
+        $response->say(
+            'Returning to the main menu',
+            ['voice' => 'Alice', 'language' => 'en-GB']
+        );
+        $response->redirect(route('welcome', [], false));
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
When using an array like this, the server is wasting processing time to build menus that will never be used.  And to add to that, if the menu option does any sort of processing, you will do that processing, even if the option wasn't selected.

This is a stop gap way of handling this.  It's not very SOLID, but it's a start.